### PR TITLE
Add water tab

### DIFF
--- a/htdocs/cscap/dl/index.phtml
+++ b/htdocs/cscap/dl/index.phtml
@@ -602,6 +602,7 @@ $t->content = <<<EOF
   <ul class="nav nav-tabs" role="tablist">
     <li role="presentation"><a href="#sites" aria-controls="sites" role="tab" data-toggle="tab">Research Sites</a></li>
     <li role="presentation" class="active"><a href="#data" aria-controls="data" role="tab" data-toggle="tab">Research Data</a></li>
+    <li role="presentation"><a href="#wdata" aria-controls="data" role="tab" data-toggle="tab">Water Data, Tools</a></li>
     <li role="presentation"><a href="#wxdata" aria-controls="data" role="tab" data-toggle="tab">Weather Data</a></li>
     <li role="presentation"><a href="#pubs" aria-controls="pubs" role="tab" data-toggle="tab">Publications</a></li>
   </ul>
@@ -1017,6 +1018,26 @@ their choice dictates the variables to be included.</i>
 
     </div>
 </div>
+
+</div>
+    <div role="tabpanel" class="tab-pane" id="wdata">
+    <h3>Water Data</h3>
+
+<p>Data originating from research sites that have subsurface tile drainage installed are included here. 
+They are not included under the Research Data tab because data are collected on a time series basis with 
+the user selecting the aggregation preferred for export.</p>
+
+<p>Datasets include:</p>
+<ul>
+<li><a href="https://datateam.agron.iastate.edu/cscap/plot_tileflow.phtml" targt="_blank">Drainage Tile Flow</a></li>
+<li><a href="https://datateam.agron.iastate.edu/cscap/plot_watertable.phtml" target="_blank">Groundwater Table Depth</a></li>
+<li><a href="https://datateam.agron.iastate.edu/cscap/plot_decagon.phtml" target="_blank">Soil Moisture and Temperature, Decagon sensors</a></li>
+<li>On-site Precipitation</li>
+</ul>
+
+    </div>
+</div>    
+
 <div class="clearfix"></div>
 <p>&nbsp;</p>
 <img src="/images/logos/web_logos.png" class="img img-responsive">


### PR DESCRIPTION
issue #47: 

- Create “Water Data, Tools” tab. Make this the third tab (after Research Data)
- On Water Data, Tools page, populate this text:

>Data originating from research sites that have subsurface tile drainage installed are included here. They are not included under the Research Data tab because data are collected on a time series basis with the user selecting the aggregation preferred for export.
>
>Datasets include (will open up in a new browser tab):
>- Drainage Tile Flow (hyperlink to https://datateam.agron.iastate.edu/cscap/plot_tileflow.phtml)
>- Groundwater Table Depth (hyperlink to https://datateam.agron.iastate.edu/cscap/plot_watertable.phtml)
>- Soil Moisture and Temperature, Decagon sensors (hyperlink to https://datateam.agron.iastate.edu/cscap/plot_decagon.phtml)
>- On-site Precipitation (to be posted soon)