### PR TITLE
change "Thesis and Dissertations" text

### DIFF
--- a/htdocs/cscap/dl/index.phtml
+++ b/htdocs/cscap/dl/index.phtml
@@ -811,7 +811,10 @@ for requests to articles below that are subscription-only.</blockquote></p>
 </div>
     <div role="tabpanel" class="tab-pane" id="p2">
 
-<h3>CSCAP Theses and Dissertations</h3>
+<p><blockquote>Many biophysical and social science graduate students were 
+supported by and contributed to the scientific discoveries and publications of 
+the Sustainable Corn CAP team. Their theses and dissertations are provided here 
+via links to their major University library.</blockquote></p>
 
 {$theseslisting}
     </div></div>


### PR DESCRIPTION
issue #53: under Thesis and Dissertations tab, delete "CSCAP Theses and Dissertations" subheader text and replace with the following. Use that side vertical beige bar like what you have for R.J.
Many biophysical and social science graduate students were supported by and contributed to the scientific discoveries and publications of the Sustainable Corn CAP team. Their theses and dissertations are provided here via links to their major University library.