### PR TITLE
remove CSCAP in title

### DIFF
--- a/htdocs/cscap/plot_decagon.phtml
+++ b/htdocs/cscap/plot_decagon.phtml
@@ -235,7 +235,9 @@ select {
 }
 </style>
 
-<h3>CSCAP Decagon Data Plotting/Download</h3>
+<p>&nbsp;</p>
+
+<h3>Decagon Data Plotting/Download</h3>
 
 <p>Decagon data included in this visualization and aggregation tool are associated with 
 the USDA-NIFA funded project: "Cropping Systems Coordinated Agricultural Project: Climate Change,


### PR DESCRIPTION
issue #53: for water plotting tools, remove "CSCAP" at the front end of each subheading. Also, add a small line up above so header is not right up against grey header.