### PR TITLE
remove CSCAP in title

### DIFF
--- a/htdocs/cscap/plot_tileflow.phtml
+++ b/htdocs/cscap/plot_tileflow.phtml
@@ -106,7 +106,9 @@ select {
 }
 </style>
 
-<h3>CSCAP Tile Flow Data Plotting/Download</h3>
+<p>&nbsp;</p>
+
+<h3>Tile Flow Data Plotting/Download</h3>
 
 <p>Tile Flow data included in this visualization and aggregation tool are associated with two
 USDA-NIFA funded projects: "Cropping Systems Coordinated Agricultural Project: Climate Change,


### PR DESCRIPTION
issue #53: for water plotting tools, remove "CSCAP" at the front end of each subheading. Also, add a small line up above so header is not right up against grey header.