### PR TITLE
remove CSCAP from title

### DIFF
--- a/htdocs/cscap/plot_watertable.phtml
+++ b/htdocs/cscap/plot_watertable.phtml
@@ -103,7 +103,9 @@ select {
 }
 </style>
 
-<h3>CSCAP Water Table Data Plotting/Download</h3>
+<p>&nbsp;</p>
+
+<h3>Water Table Data Plotting/Download</h3>
 
 <p>Water Table Depth data included in this visualization and aggregation tool are associated with two
 USDA-NIFA funded projects: "Cropping Systems Coordinated Agricultural Project: Climate Change,


### PR DESCRIPTION
issue #53:  for water plotting tools, remove "CSCAP" at the front end of each subheading. Also, add a small line up above so header is not right up against grey header.