### PR TITLE
add text

### DIFF
--- a/htdocs/cscap/dl/index.phtml
+++ b/htdocs/cscap/dl/index.phtml
@@ -834,7 +834,10 @@ via links to their major University library.</blockquote></p>
 
 <p>Data originating from research sites that have subsurface tile drainage installed are included here. 
 They are not included under the Research Data tab because data are collected on a time series basis with 
-the user selecting the aggregation preferred for export.</p>
+the user selecting the aggregation preferred for export. Please note that additional data such as management 
+operations, plot identifiers, data dictionary, and site history for these drainage research sites are included 
+under the Research Data tab. It is strongly recommended to download these supporting data to properly interpret 
+and synthesize water data contained here.</p>
 
 <p>Datasets include:</p>
 <ul>


### PR DESCRIPTION
issue #53: add this onto Water Data, Tools page as the third and fourth sentences.
Please note that additional data such as management operations, plot identifiers, data dictionary, and site history for these drainage research sites are included under the Research Data tab. It is strongly recommended to download these supporting data to properly interpret and synthesize water data contained here.