### PR TITLE
remove text

### DIFF
--- a/htdocs/cscap/dl/index.phtml
+++ b/htdocs/cscap/dl/index.phtml
@@ -1091,18 +1091,6 @@ their choice dictates the variables to be included.</i>
 
 <div class="clearfix"><p>&nbsp;</p></div>
 
-<h3>Biophysical Data</h3>
-
-<p>Research data, from the management practices being studied, were collected 
-over 5 years from 30 field research sites throughout the project area and 
-integrated with climate science data. The practices were: corn-soybean rotation, 
-cereal rye cover crop within the corn-soybean rotation, extended and diverse crop 
-rotations, drainage water management, canopy nitrogen sensing, tillage management 
-and differing landscape positions.</p>
-
-
-<h3>Social Economic Data</h3>
-
 <p>Social economic research was conducted and included a survey of 4,778 farmers 
 in 11 Corn Belt states and 156 one-hour, in-person farmer interviews. The data 
 cannot be released due to anonymity issues but are available in aggregated 


### PR DESCRIPTION
issue #83: under Soc Econ tab > delete biophysical research heading and corresponding text and also subheading Soc Econ since the tab has that name.