### PR TITLE
add text

### DIFF
--- a/htdocs/cscap/dl/index.phtml
+++ b/htdocs/cscap/dl/index.phtml
@@ -1083,6 +1083,10 @@ their choice dictates the variables to be included.</i>
     <option value="tab">Tab
    </select></p>
 
+<p>The downloaded data file will have the name of the networked 
+Weather Station. Refer to the drop-down above for reminder as to 
+which site it corresponds with.</p>
+
 <p><input type="submit" value="Request Data" /></p>
 </form>
 


### PR DESCRIPTION
issue #83: above Download tab for weather data include this statement or something better: The downloaded data file will have the name of the networked Weather Station. Refer to the drop-down above for reminder as to which site it corresponds with.