### PR TITLE
adjust table size

### DIFF
--- a/htdocs/cscap/plot_watertable.phtml
+++ b/htdocs/cscap/plot_watertable.phtml
@@ -130,7 +130,7 @@ Mitigation, and Adaptation in Corn-based Cropping Systems." (Award No. 2011-6800
 <td><input type="text" id="datepicker" name="date" value="{$date}" size="11" /></td>
 </tr></tbody></table>
 
-<table class="table table-bordered table-nonfluid">
+<table class="table table-bordered">
 <thead><tr><th>Number of Days to Plot</th>
 <th>Time-series Aggregation:</th><th>View and Download Options</th></tr></thead>
 <tbody><tr>


### PR DESCRIPTION
@akrherz - table for selecting input data was not stretching along the whole width of the page like other tools do. I think this is a piece of code that prevented this automagic to happen, so I deleted it (`table-nonfluid`) . 