### PR TITLE
Link a folder

### DIFF
--- a/htdocs/cscap/dl/sites.html
+++ b/htdocs/cscap/dl/sites.html
@@ -397,9 +397,6 @@ Sustainable Corn CAP which can be seen in the plot map.</li>
 			</p>
 		</td>
 		<td>
-			<p><a target="_blank" href="https://drive.google.com/open?id=0B_Wz65q1Dw-0Slk4dFJNMVlpNkk"><i class="fa fa-camera"></i> Link</a>
-			
-			</p>
 		</td>
 	</tr>
 	<tr valign="top">
@@ -475,6 +472,9 @@ Sustainable Corn CAP which can be seen in the plot map.</li>
 			</p>
 		</td>
 		<td>
+			<p><a target="_blank" href="https://drive.google.com/open?id=0B_Wz65q1Dw-0R3hMeXc0LUZpVEU"><i class="fa fa-camera"></i> Link</a>
+			
+			</p>
 		</td>
 	</tr>
 	<tr valign="top">


### PR DESCRIPTION
Issue #83: remove link to BRADFORD.A photos from Research Sites tab. Add new link to BRADFORD.C photos (https://drive.google.com/open?id=0B_Wz65q1Dw-0R3hMeXc0LUZpVEU)