### PR TITLE
Change drop-down list

### DIFF
--- a/include/templates/navbar.phtml
+++ b/include/templates/navbar.phtml
@@ -11,10 +11,10 @@ $_pages = Array(
             "base" => Array("title" => "Homepage", "url" => "/cscap/"),
             "data" => Array("title" => "Research Data", "url" => "/cscap/dl/"),
             "usage" => Array("title" => "Data Usage Agreement", "url" => "/cscap/usage.phtml"),
-            "tileflow" => Array("title" => "Tile Flow Data Plotting", "url" => "/cscap/plot_tileflow.phtml"),
+            <!-- "tileflow" => Array("title" => "Tile Flow Data Plotting", "url" => "/cscap/plot_tileflow.phtml"),
             "watertable" => Array("title" => "Water Table Depth Data Plotting", "url" => "/cscap/plot_watertable.phtml"),
             "waterquality" => Array("title" => "Water Quality Data Plotting", "url" => "/cscap/plot_waterquality.phtml"),
-            "decagon" => Array("title" => "Decagon Data Plotting", "url" => "/cscap/plot_decagon.phtml"),
+            "decagon" => Array("title" => "Decagon Data Plotting", "url" => "/cscap/plot_decagon.phtml"), -->
             ),
         ),
     "td" => Array(


### PR DESCRIPTION
Issue #134: 
* remove 4 "data plotting" tools from drop down list if possible. People will access within Research Data tab instead.