### PR TITLE
more rotation codes conversions

### DIFF
--- a/htdocs/cscap/dl/dl.py
+++ b/htdocs/cscap/dl/dl.py
@@ -92,9 +92,10 @@ ROT_CODES = {
     "ROT9": "ROT6v",
     "ROT58": "ROT38v",
     "ROT60": "ROT36v",
-    "ROT61": "ROT1v",
+    "ROT61": "ROT5v",
     "ROT62": "ROT7v",
     "ROT54": "ROT5v",
+    "ROT57": "ROT37v",
     "ROT55": "ROT37v",
     "ROT56": "ROT1v",
     }


### PR DESCRIPTION
Issues #134 
- ROT61 was converted to ROT1v; convert to ROT5v instead. ROT61 only occurs at ISUAG.USB so no other changes needed.
- ROT57 should be converted to ROT37v for export. Only occurs at ISUAG.USB so no other changes needed.